### PR TITLE
Fix cases where the user enters an invalid localisation

### DIFF
--- a/src/modules/stockpile_viewer/ModuleStockpile.py
+++ b/src/modules/stockpile_viewer/ModuleStockpile.py
@@ -59,11 +59,17 @@ class ModuleStockpiles(commands.Cog):
     @app_commands.autocomplete(localisation=region_autocomplete)
     async def stockpile_create(self, interaction: discord.Interaction, code: str, localisation: str, *, name: str):
         print(f'> stockpile_create command by {interaction.user.name} on {interaction.guild.name}')
+        # Case where a user entered an invalid sized code
         if len(code) != 6:
             await interaction.response.send_message('> The code must be a 6-digits code', ephemeral=True)
             return
+        # Case where a user entered a code without digits only
         if not code.isdigit():
             await interaction.response.send_message('> The code contains non digit characters', ephemeral=True)
+            return
+        # Case where a user did not select a provided localisation
+        if ' | ' not in localisation or localisation.startswith(' | ') or localisation.startswith(' | '):
+            await interaction.response.send_message('> The localisation you entered is incorrect, displayed localisations are clickable', ephemeral=True)
             return
 
         r, s = localisation.split(' | ')  # Only one '|' -> 2 splits


### PR DESCRIPTION
**OISOL | Version 27**
__Stockpile__
- Fix de l'erreur pour quand un utilisateur donne un lieu invalide dans `/stockpile-create`